### PR TITLE
Add warning to downloads page

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -5,6 +5,10 @@ foot:
     "/js/downloads.js"
 ---
 {% include head.html %}
+<div class="container alert alert-danger" style='margin-bottom: 10px'>
+  <strong>These builds are released for development purposes only!</strong><br/>
+  Glowstone is not quite ready for live server usage just yet. Use at your own risk.
+</div>
 <div class="container">
   <table id="builds" class="table table-bordered table-hover">
     <tr>


### PR DESCRIPTION
People keep expecting Glowstone to work for production environments. This is not true (yet!)

Images of the error (cause I'm too damn lazy to expose the server port):
- [Chrome](http://i.turt2live.com/w94N.png)
- [Firefox](http://i.turt2live.com/wBRX.png)
- [IE11](http://i.turt2live.com/0i5P.png)

And for those too lazy to click a link:
![image](https://cloud.githubusercontent.com/assets/1190097/4604224/08f0d6e8-518d-11e4-981a-b122d6e7fffc.png)

Edit: Here's a live preview: http://home.turt2live.com:4000
